### PR TITLE
Old-style RE specificity fix

### DIFF
--- a/kod/object/active/holder/nomoveon.kod
+++ b/kod/object/active/holder/nomoveon.kod
@@ -184,7 +184,7 @@ messages:
       return;
    }
 
-   AddRadiusEnchantment(what=$,iPower=0,source=$)
+   AddRadiusEnchantment(what=$,iPower=0,source=$,oRoom=$)
    {
       local i;
       
@@ -193,12 +193,14 @@ messages:
          if Nth(i,1) = what
             AND Nth(i,2) = iPower
             AND Nth(i,3) = source
+            AND Nth(i,4) = oRoom
          {
             return;
          }
       }
 
-      plRadiusEnchantments = Cons([what,iPower,source],plRadiusEnchantments);
+      plRadiusEnchantments = Cons([what,iPower,source,oRoom],
+                                   plRadiusEnchantments);
       
       If IsClass(self,&User)
       {
@@ -214,7 +216,7 @@ messages:
       return;
    }
 
-   RemoveRadiusEnchantment(what=$,iPower=0,source=$)
+   RemoveRadiusEnchantment(what=$,iPower=0,source=$,oRoom=$)
    {
       local i;
 
@@ -223,6 +225,7 @@ messages:
          if Nth(i,1) = what
             AND Nth(i,2) = iPower
             AND Nth(i,3) = source
+            AND Nth(i,4) = oRoom
          {
             If IsClass(self,&User)
             {

--- a/kod/object/passive/spell/radiusench.kod
+++ b/kod/object/passive/spell/radiusench.kod
@@ -21,7 +21,7 @@ RadiusEnchantment is Spell
 % For example, a spell may have a Power range 1-20, or a Power range not based on spellpower at all.
 %
 % EnterRadius and LeaveRadius add or remove from an object's plRadiusEnchantments list.
-% Each element is of the form [spell object, spellpower, caster].
+% Each element is of the form [spell object, spellpower, caster, origin room].
 % These states should be used when effects are actually being performed,
 % and should be called by the objects themselves. For example, a player swinging a mace will
 % check his plRadiusEnchantments list for spells that affect mace swings, and call them appropriately.
@@ -254,7 +254,9 @@ messages:
          return 0;
       }
 
-      plCurrentEnchantments = Cons([source,0,0,$,iPower,iRange,iDuration,oRoom],plCurrentEnchantments);
+      plCurrentEnchantments = Cons([source,0,0,$,
+                                    iPower,iRange,iDuration,oRoom],
+                                    plCurrentEnchantments);
 
       Send(self,@RecalculateActiveEnchantments);
 
@@ -306,6 +308,27 @@ messages:
             Debug("Radius check went off without a proper room!",self);
          }
 
+         % Check for objects that have left the radius of effect
+         % We must leave first so that similar spells can reapply later
+         foreach oObject in lEnchanted
+         {
+            iDistance = Send(source,@SquaredDistanceTo,#what=oObject);
+            if ((iDistance = $
+               OR iDistance > (iRange * iRange))
+                  AND NOT piOldAreaEnchStyle)
+               OR NOT Send(self,@TargetIsValid,#target=oObject,#source=source)
+               OR (piOldAreaEnchStyle
+                   AND (Send(oObject,@GetOwner) = $
+                        OR Send(oObject,@GetOwner) <> oRoom))
+            {
+               Send(self,@LeaveRadius,#what=oObject,
+                                      #iPower=iPower,
+                                      #source=source,
+                                      #oRoom=oRoom);
+               lEnchanted = DelListElem(lEnchanted,oObject);
+            }
+         }
+
          % Check for active objects that have entered the radius of effect
          foreach oActive in Send(oRoom,@GetPlActive)
          {
@@ -319,7 +342,10 @@ messages:
             {
                if Send(self,@TargetIsValid,#target=oObject,#source=source)
                {
-                  Send(self,@EnterRadius,#what=oObject,#iPower=iPower,#source=source);
+                  Send(self,@EnterRadius,#what=oObject,
+                                         #iPower=iPower,
+                                         #source=source,
+                                         #oRoom=oRoom);
                   lEnchanted = Cons(oObject,lEnchanted);
                }
             }
@@ -340,27 +366,13 @@ messages:
                {
                   if Send(self,@TargetIsValid,#target=oObject,#source=source)
                   {
-                     Send(self,@EnterRadius,#what=oObject,#iPower=iPower,#source=source);
+                     Send(self,@EnterRadius,#what=oObject,
+                                            #iPower=iPower,
+                                            #source=source,
+                                            #oRoom=oRoom);
                      lEnchanted = Cons(oObject,lEnchanted);
                   }
                }
-            }
-         }
-
-         % Check for objects that have left the radius of effect
-         foreach oObject in lEnchanted
-         {
-            iDistance = Send(source,@SquaredDistanceTo,#what=oObject);
-            if ((iDistance = $
-               OR iDistance > (iRange * iRange))
-                  AND NOT piOldAreaEnchStyle)
-               OR NOT Send(self,@TargetIsValid,#target=oObject,#source=source)
-               OR (piOldAreaEnchStyle
-                   AND (Send(oObject,@GetOwner) = $
-                        OR Send(oObject,@GetOwner) <> oRoom))
-            {
-               Send(self,@LeaveRadius,#what=oObject,#iPower=iPower,#source=source);
-               lEnchanted = DelListElem(lEnchanted,oObject);
             }
          }
 
@@ -571,9 +583,12 @@ messages:
       return FALSE;
    }
 
-   EnterRadius(what=$,iPower=0,source=$)
+   EnterRadius(what=$,iPower=0,source=$,oRoom=$)
    {
-      Send(what,@AddRadiusEnchantment,#what=self,#iPower=iPower,#source=source);
+      Send(what,@AddRadiusEnchantment,#what=self,
+                                      #iPower=iPower,
+                                      #source=source,
+                                      #oRoom=oRoom);
 
       if IsClass(what,&User)
       {
@@ -583,7 +598,8 @@ messages:
          }
          else
          {
-            Send(what,@MsgSendUser,#message_rsc=radius_ench_enter,#parm1=Send(source,@GetName));
+            Send(what,@MsgSendUser,#message_rsc=radius_ench_enter,
+                                   #parm1=Send(source,@GetName));
          }
       }
 
@@ -592,9 +608,12 @@ messages:
       return;
    }
 
-   LeaveRadius(what=$,iPower=0,source=$)
+   LeaveRadius(what=$,iPower=0,source=$,oRoom=$)
    {
-      Send(what,@RemoveRadiusEnchantment,#what=self,#iPower=iPower,#source=source);
+      Send(what,@RemoveRadiusEnchantment,#what=self,
+                                         #iPower=iPower,
+                                         #source=source,
+                                         #oRoom=oRoom);
       
       if IsClass(what,&User)
       {
@@ -604,7 +623,8 @@ messages:
          }
          else
          {
-            Send(what,@MsgSendUser,#message_rsc=radius_ench_leave,#parm1=Send(source,@GetName));
+            Send(what,@MsgSendUser,#message_rsc=radius_ench_leave,
+                                   #parm1=Send(source,@GetName));
          }
       }
 
@@ -691,11 +711,6 @@ messages:
             iPower = Nth(i,5);
             iRange = Nth(i,6);
 
-            foreach oObj in lEnchanted
-            {
-               Send(self,@LeaveRadius,#what=oObj,#iPower=iPower,#source=source);
-            }
-
             if piOldAreaEnchStyle
             {
                oRoom = Nth(i,8);
@@ -703,6 +718,14 @@ messages:
             else
             {
                oRoom = Send(source,@GetOwner);
+            }
+
+            foreach oObj in lEnchanted
+            {
+               Send(self,@LeaveRadius,#what=oObj,
+                                      #iPower=iPower,
+                                      #source=source,
+                                      #oRoom=oRoom);
             }
 
             if oRoom <> $


### PR DESCRIPTION
This adds a fourth parameter to Radius Enchantment information - the
source room. This helps differentiate between two old-style REs cast by
the same source in two different rooms. This prevents icon loss and
duplicates when moving between two rooms that have the same old-style
AE, same caster, and same spellpower.
